### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           VERSION: '3.0'
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -543,7 +543,7 @@ jobs:
           input: ./build/index.html.dist
           output: ./build/index.html
       - name: Build
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           VERSION: '3.0'
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore